### PR TITLE
feat: add ONNX to the graph encoding enum

### DIFF
--- a/phases/ephemeral/docs.md
+++ b/phases/ephemeral/docs.md
@@ -1328,6 +1328,8 @@ TODO document buffer order
 
 - <a href="#graph_encoding.tensorflow" name="graph_encoding.tensorflow"></a> `tensorflow`
 
+- <a href="#graph_encoding.onnx" name="graph_encoding.onnx"></a> `onnx`
+
 ## <a href="#execution_target" name="execution_target"></a> `execution_target`: `Variant`
 Define where the graph should be executed.
 

--- a/phases/ephemeral/witx/wasi_ephemeral_nn.witx
+++ b/phases/ephemeral/witx/wasi_ephemeral_nn.witx
@@ -82,6 +82,7 @@
     ;;; TODO document buffer order
     $openvino
     $tensorflow
+    $onnx
   )
 )
 


### PR DESCRIPTION
This commit adds ONNX to the graph encoding enum, preparing
the addition of an ONNX implementation for WASI NN.
(see https://github.com/deislabs/wasi-nn-onnx for an implementation).


Signed-off-by: Radu Matei <radu.matei@fermyon.com>