### PR TITLE
Fix `get-output` return type

### DIFF
--- a/wasi-nn.abi.md
+++ b/wasi-nn.abi.md
@@ -175,5 +175,5 @@ Size: 1, Alignment: 1
 - <a href="#get_output.index" name="get_output.index"></a> `index`: `u32`
 ##### Result
 
-- expected<[`tensor`](#tensor), [`error`](#error)>
+- expected<[`tensor-data`](#tensor_data), [`error`](#error)>
 

--- a/wasi-nn.wit.md
+++ b/wasi-nn.wit.md
@@ -114,7 +114,7 @@ set-input: func(ctx: graph-execution-context, index: u32, tensor: tensor) -> exp
 compute: func(ctx: graph-execution-context) -> expected<unit, error>
 
 // Extract the outputs after inference.
-get-output: func(ctx: graph-execution-context, index: u32) -> expected<tensor, error>
+get-output: func(ctx: graph-execution-context, index: u32) -> expected<tensor-data, error>
 ```
 
 ### Errors


### PR DESCRIPTION
In porting the WITX definition to WIT, I inadvertently changed the
return type of `get-output`. @yamt identified this issue in #24--thank
you! This change fixes the return type to the original type,
`tensor-data`. (In the future, it may be interesting to return more
information about the tensor, but that can be a separate issue).