### PR TITLE
Re-add `*.witx` version of API

### DIFF
--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -1,0 +1,82 @@
+;; This WITX version of the wasi-nn API is retained for consistency only. See the `wasi-nn.wit.md`
+;; version for the official specification and documentation.
+
+(typename $buffer_size u32)
+(typename $nn_errno
+  (enum (@witx tag u16)
+    $success
+    $invalid_argument
+    $invalid_encoding
+    $missing_memory
+    $busy
+    $runtime_error
+  )
+)
+(typename $tensor_dimensions (list u32))
+(typename $tensor_type
+  (enum (@witx tag u8)
+    $f16
+    $f32
+    $u8
+    $i32
+  )
+)
+(typename $tensor_data (list u8))
+(typename $tensor
+  (record
+    (field $dimensions $tensor_dimensions)
+    (field $type $tensor_type)
+    (field $data $tensor_data)
+  )
+)
+(typename $graph_builder (list u8))
+(typename $graph_builder_array (list $graph_builder))
+(typename $graph (handle))
+(typename $graph_encoding
+  (enum (@witx tag u8)
+    $openvino
+    $onnx
+    $tensorflow
+    $pytorch
+  )
+)
+(typename $execution_target
+  (enum (@witx tag u8)
+    $cpu
+    $gpu
+    $tpu
+  )
+)
+(typename $graph_execution_context (handle))
+
+(module $wasi_ephemeral_nn
+  (import "memory" (memory))
+  (@interface func (export "load")
+    (param $builder $graph_builder_array)
+    (param $encoding $graph_encoding)
+    (param $target $execution_target)
+    (result $error (expected $graph (error $nn_errno)))
+  )
+  (@interface func (export "init_execution_context")
+    (param $graph $graph)
+    (result $error (expected $graph_execution_context (error $nn_errno)))
+  )
+  (@interface func (export "set_input")
+    (param $context $graph_execution_context)
+    (param $index u32)
+    (param $tensor $tensor)
+    (result $error (expected (error $nn_errno)))
+  )
+  (@interface func (export "get_output")
+    (param $context $graph_execution_context)
+    (param $index u32)
+    (param $out_buffer (@witx pointer u8))
+    (param $out_buffer_max_size $buffer_size)
+    (result $error (expected $buffer_size (error $nn_errno)))
+  )
+  (@interface func (export "compute")
+    (param $context $graph_execution_context)
+    (result $error (expected (error $nn_errno)))
+  )
+)
+


### PR DESCRIPTION
After some discussion with `wit-bindgen` maintainers, it is clear that
that tool is not yet ready to use for implementing WASI APIs inside
engines (e.g., Wasmtime). Since the existing Wasmtime infrastructure,
`wiggle`, uses the WITX syntax, this change re-adds the WITX version of
the wasi-nn API. This allows `wiggle` to continue to pull the WITX
specification directly from this repository until it is replaced by
`wit-bindgen`. All documentation has been removed from `wasi-nn.witx`
since we expect the WIT version to be the official version (at some
point, it would be nice to check in CI that the WITX and WIT versions expose
an identical API but this API does not do that).