### PR TITLE
Clean up `*.witx`

### DIFF
--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -2,8 +2,6 @@
 ;; version for the official specification and documentation.
 
 (typename $buffer_size u32)
-(typename $status u32)
-
 (typename $nn_errno
   (enum (@witx tag u16)
     $success
@@ -64,17 +62,10 @@
     (param $target $execution_target)
     (result $error (expected $graph (error $nn_errno)))
   )
-  ;;; Load an opaque sequence of bytes to use for inference.
-  ;;;
-  ;;; This allows runtime implementations to support multiple graph encoding formats. For unsupported graph encodings,
-  ;;; return `errno::inval`.
   (@interface func (export "load_by_name")
-     ;;; The name of the model to load from the model registry
      (param $model_name string)
-
      (result $error (expected $graph (error $nn_errno)))
   )
-
   (@interface func (export "init_execution_context")
     (param $graph $graph)
     (result $error (expected $graph_execution_context (error $nn_errno)))
@@ -97,4 +88,3 @@
     (result $error (expected (error $nn_errno)))
   )
 )
-


### PR DESCRIPTION
This removes an unused type (`status`) as well as some documentation to avoid duplication with the `*.wit` version of the same API (I'll try to keep the documentation up to date thre.