### PR TITLE
Use "graph" name in the API

### DIFF
--- a/ml-example.md
+++ b/ml-example.md
@@ -2,7 +2,7 @@
 <p><code>wasi-nn</code> is a WASI API for performing machine learning (ML) inference. The API is not (yet)
 capable of performing ML training. WebAssembly programs that want to use a host's ML
 capabilities can access these capabilities through <code>wasi-nn</code>'s core abstractions: <em>graphs</em> and
-<em>tensors</em>. A user <a href="#load"><code>load</code></a>s a model -- instantiated as a <em>graph</em> -- to use in an ML <em>backend</em>.
+<em>tensors</em>. A user <a href="#load"><code>load</code></a>s an ML model -- instantiated as a <em>graph</em> -- to use in an ML <em>backend</em>.
 Then, the user passes <em>tensor</em> inputs to the <em>graph</em>, computes the inference, and retrieves the
 <em>tensor</em> outputs.</p>
 <p>This example world shows how to use these primitives together.</p>
@@ -62,8 +62,8 @@ memory--e.g., using row-major ordering--and could perhaps be improved.</p>
 <li><a name="error.busy"><code>busy</code></a></li>
 <li><a name="error.runtime_error"><code>runtime-error</code></a></li>
 <li><a name="error.unsupported_operation"><code>unsupported-operation</code></a></li>
-<li><a name="error.model_too_large"><code>model-too-large</code></a></li>
-<li><a name="error.model_not_found"><code>model-not-found</code></a></li>
+<li><a name="error.too_large"><code>too-large</code></a></li>
+<li><a name="error.not_found"><code>not-found</code></a></li>
 </ul>
 <h2><a name="wasi:nn_graph">Import interface wasi:nn/graph</a></h2>
 <p>A <a href="#graph"><code>graph</code></a> is a loaded instance of a specific ML model (e.g., MobileNet) for a specific ML
@@ -119,18 +119,18 @@ graph IR in parts (e.g., OpenVINO stores its IR and weights separately).</p>
 <ul>
 <li><a name="load.0"></a> result&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="load_named_model"><code>load-named-model: func</code></a></h4>
+<h4><a name="load_by_name"><code>load-by-name: func</code></a></h4>
 <p>Load a <a href="#graph"><code>graph</code></a> by name.</p>
 <p>How the host expects the names to be passed and how it stores the graphs for retrieval via
 this function is <strong>implementation-specific</strong>. This allows hosts to choose name schemes that
 range from simple to complex (e.g., URLs?) and caching mechanisms of various kinds.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="load_named_model.name"><code>name</code></a>: <code>string</code></li>
+<li><a name="load_by_name.name"><code>name</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="load_named_model.0"></a> result&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="load_by_name.0"></a> result&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h2><a name="wasi:nn_inference">Import interface wasi:nn/inference</a></h2>
 <p>An inference &quot;session&quot; is encapsulated by a <a href="#graph_execution_context"><code>graph-execution-context</code></a>. This structure binds a

--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -11,8 +11,8 @@
     $busy
     $runtime_error
     $unsupported_operation
-    $model_too_large
-    $model_not_found
+    $too_large
+    $not_found
   )
 )
 (typename $tensor_dimensions (list u32))
@@ -63,7 +63,7 @@
     (result $error (expected $graph (error $nn_errno)))
   )
   (@interface func (export "load_by_name")
-     (param $model_name string)
+     (param $name string)
      (result $error (expected $graph (error $nn_errno)))
   )
   (@interface func (export "init_execution_context")

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -3,7 +3,7 @@ package wasi:nn
 /// `wasi-nn` is a WASI API for performing machine learning (ML) inference. The API is not (yet)
 /// capable of performing ML training. WebAssembly programs that want to use a host's ML
 /// capabilities can access these capabilities through `wasi-nn`'s core abstractions: _graphs_ and
-/// _tensors_. A user `load`s a model -- instantiated as a _graph_ -- to use in an ML _backend_.
+/// _tensors_. A user `load`s an ML model -- instantiated as a _graph_ -- to use in an ML _backend_.
 /// Then, the user passes _tensor_ inputs to the _graph_, computes the inference, and retrieves the
 /// _tensor_ outputs.
 ///
@@ -97,7 +97,7 @@ interface graph {
     /// How the host expects the names to be passed and how it stores the graphs for retrieval via
     /// this function is **implementation-specific**. This allows hosts to choose name schemes that
     /// range from simple to complex (e.g., URLs?) and caching mechanisms of various kinds.
-    load-named-model: func(name: string) -> result<graph, error>
+    load-by-name: func(name: string) -> result<graph, error>
 }
 
 /// An inference "session" is encapsulated by a `graph-execution-context`. This structure binds a
@@ -138,11 +138,11 @@ interface errors {
         busy,
         // Runtime Error.
         runtime-error,
-        // Unsupported operation
+        // Unsupported operation.
         unsupported-operation,
-        // Model too large
-        model-too-large,
-        // Model not found
-        model-not-found
+        // Graph is too large.
+        too-large,
+        // Graph not found.
+        not-found
     }
 }


### PR DESCRIPTION
The API uses the word "graph" to describe the instantiation of an ML model. This change uses "graph" consistently where previously "model" was used.