### PR TITLE
Adding 64 bit tensor data types

### DIFF
--- a/ml.md
+++ b/ml.md
@@ -26,9 +26,11 @@ Then, the user passes <em>tensor</em> inputs to the <em>graph</em>, computes the
 <ul>
 <li><a name="tensor_type.fp16"><code>FP16</code></a></li>
 <li><a name="tensor_type.fp32"><code>FP32</code></a></li>
+<li><a name="tensor_type.fp64"><code>FP64</code></a></li>
 <li><a name="tensor_type.bf16"><code>BF16</code></a></li>
 <li><a name="tensor_type.u8"><code>U8</code></a></li>
 <li><a name="tensor_type.i32"><code>I32</code></a></li>
+<li><a name="tensor_type.i64"><code>I64</code></a></li>
 </ul>
 <h4><a name="tensor_dimensions"><code>type tensor-dimensions</code></a></h4>
 <p><a href="#tensor_dimensions"><a href="#tensor_dimensions"><code>tensor-dimensions</code></a></a></p>

--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -20,7 +20,7 @@
   (enum (@witx tag u8)
     $f16
     $f32
-    $f32
+    $f64
     $u8
     $i32
     $i64

--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -20,8 +20,10 @@
   (enum (@witx tag u8)
     $f16
     $f32
+    $f32
     $u8
     $i32
+    $i64
   )
 )
 (typename $tensor_data (list u8))

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -27,9 +27,11 @@ interface tensor {
     enum tensor-type {
         FP16,
         FP32,
+        FP64,
         BF16,
         U8,
-        I32
+        I32,
+        I64
     }
 
     /// The tensor data.


### PR DESCRIPTION
In testing this interface with commonly available models, there are data types missing in the specification.  I have added here both integer and floating point 64-bit types as these are defined in the WASM specification as native types.

There are many other types defined by the frameworks listed in the specification.  Is the goal to provide an interface which is a superset of these types or simply represent the most common.  For example, many of the quantized types are primarily used internally, not at the input/output boundary. 