### PR TITLE
Update contributing guide to use `wit-bindgen`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,12 +8,12 @@ same guidelines as the [WASI contribution guidelines].
 The specification is written in WIT (WebAssembly Interface Types) &mdash; see `wit/wasi-nn.wit`.
 This is parseable by WIT tools (e.g., [`wit-bindgen`], [`wit-abi`]). Note that, when altering the
 WIT specification, the Markdown example file (`ml-example.md`) must also be updated or CI will fail.
-To use [`wit-abi`] to update the ABI file, run:
+To use [`wit-bindgen`] to update the ABI file, run:
 
 [`wit-bindgen`]: https://github.com/bytecodealliance/wit-bindgen
 [`wit-abi`]: https://github.com/WebAssembly/wasi-tools/tree/main/wit-abi
 
 ```console
-$ cargo install wit-abi --locked --git https://github.com/WebAssembly/wasi-tools --tag wit-abi-0.11.0
-$ wit-abi markdown --html-in-md wit
+$ cargo install wit-bindgen-cli@0.12.0
+$ wit-bindgen markdown --html-in-md wit
 ```


### PR DESCRIPTION
I believe, from [looking](https://github.com/WebAssembly/wit-abi-up-to-date/blob/5f8e3b9e66c40e4895ecf5b1190a16eb84a265cd/action.yml#L24C12-L24C57) at the `wit-abi-up-to-date` action, that the current best practice is to use `wit-bindgen` to generate the markdown.