### PR TITLE
Add kserve backend.

### DIFF
--- a/wasi-nn.witx
+++ b/wasi-nn.witx
@@ -44,6 +44,7 @@
     $tensorflow
     $pytorch
     $tensorflowlite
+    $kserve
     $autodetect
   )
 )

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -75,6 +75,7 @@ interface graph {
         tensorflow,
         pytorch,
         tensorflowlite,
+        kserve,
         autodetect,
     }
 


### PR DESCRIPTION
Due to the changes in bytecodealliance/wasmtime#6893, we should have an explicit enum entry for kserve backend as the graph encoding is now used to identify the backend and it would conflict with an autodetect feature.