### PR TITLE
Simple proposal to extend error handling.

### DIFF
--- a/ml.md
+++ b/ml.md
@@ -109,22 +109,22 @@ memory--e.g., using row-major ordering--and could perhaps be improved.</p>
 <h4><a name="constructor_error"><code>[constructor]error: func</code></a></h4>
 <h5>Params</h5>
 <ul>
-<li><a name="constructor_error.error"><a href="#error"><code>error</code></a></a>: <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
+<li><a name="constructor_error.code"><code>code</code></a>: <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
 <li><a name="constructor_error.data"><code>data</code></a>: <code>string</code></li>
 </ul>
 <h5>Return values</h5>
 <ul>
 <li><a name="constructor_error.0"></a> own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
-<h4><a name="method_error.error"><code>[method]error.error: func</code></a></h4>
+<h4><a name="method_error.code"><code>[method]error.code: func</code></a></h4>
 <p>Return the error code.</p>
 <h5>Params</h5>
 <ul>
-<li><a name="method_error.error.self"><code>self</code></a>: borrow&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_error.code.self"><code>self</code></a>: borrow&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_error.error.0"></a> <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
+<li><a name="method_error.code.0"></a> <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
 </ul>
 <h4><a name="method_error.data"><code>[method]error.data: func</code></a></h4>
 <p>Errors can propagated with backend specific status through a string value.</p>

--- a/ml.md
+++ b/ml.md
@@ -90,16 +90,51 @@ memory--e.g., using row-major ordering--and could perhaps be improved.</p>
 <p>TODO: create function-specific errors (https://github.com/WebAssembly/wasi-nn/issues/42)</p>
 <hr />
 <h3>Types</h3>
-<h4><a name="error"><code>enum error</code></a></h4>
+<h4><a name="error_code"><code>enum error-code</code></a></h4>
 <h5>Enum Cases</h5>
 <ul>
-<li><a name="error.invalid_argument"><code>invalid-argument</code></a></li>
-<li><a name="error.invalid_encoding"><code>invalid-encoding</code></a></li>
-<li><a name="error.busy"><code>busy</code></a></li>
-<li><a name="error.runtime_error"><code>runtime-error</code></a></li>
-<li><a name="error.unsupported_operation"><code>unsupported-operation</code></a></li>
-<li><a name="error.too_large"><code>too-large</code></a></li>
-<li><a name="error.not_found"><code>not-found</code></a></li>
+<li><a name="error_code.invalid_argument"><code>invalid-argument</code></a></li>
+<li><a name="error_code.invalid_encoding"><code>invalid-encoding</code></a></li>
+<li><a name="error_code.timeout"><code>timeout</code></a></li>
+<li><a name="error_code.runtime_error"><code>runtime-error</code></a></li>
+<li><a name="error_code.unsupported_operation"><code>unsupported-operation</code></a></li>
+<li><a name="error_code.too_large"><code>too-large</code></a></li>
+<li><a name="error_code.not_found"><code>not-found</code></a></li>
+<li><a name="error_code.security"><code>security</code></a></li>
+<li><a name="error_code.unknown"><code>unknown</code></a></li>
+</ul>
+<h4><a name="error"><code>resource error</code></a></h4>
+<hr />
+<h3>Functions</h3>
+<h4><a name="constructor_error"><code>[constructor]error: func</code></a></h4>
+<h5>Params</h5>
+<ul>
+<li><a name="constructor_error.error"><a href="#error"><code>error</code></a></a>: <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
+<li><a name="constructor_error.data"><code>data</code></a>: <code>string</code></li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="constructor_error.0"></a> own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+</ul>
+<h4><a name="method_error.error"><code>[method]error.error: func</code></a></h4>
+<p>Return the error code.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_error.error.self"><code>self</code></a>: borrow&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="method_error.error.0"></a> <a href="#error_code"><a href="#error_code"><code>error-code</code></a></a></li>
+</ul>
+<h4><a name="method_error.data"><code>[method]error.data: func</code></a></h4>
+<p>Errors can propagated with backend specific status through a string value.</p>
+<h5>Params</h5>
+<ul>
+<li><a name="method_error.data.self"><code>self</code></a>: borrow&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+</ul>
+<h5>Return values</h5>
+<ul>
+<li><a name="method_error.data.0"></a> <code>string</code></li>
 </ul>
 <h2><a name="wasi:nn_inference">Import interface wasi:nn/inference</a></h2>
 <p>An inference &quot;session&quot; is encapsulated by a <a href="#graph_execution_context"><code>graph-execution-context</code></a>. This structure binds a
@@ -128,7 +163,7 @@ memory--e.g., using row-major ordering--and could perhaps be improved.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_graph_execution_context.set_input.0"></a> result&lt;_, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_graph_execution_context.set_input.0"></a> result&lt;_, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_graph_execution_context.compute"><code>[method]graph-execution-context.compute: func</code></a></h4>
 <p>Compute the inference on the given inputs.</p>
@@ -141,7 +176,7 @@ https://github.com/WebAssembly/wasi-nn/issues/43.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_graph_execution_context.compute.0"></a> result&lt;_, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_graph_execution_context.compute.0"></a> result&lt;_, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="method_graph_execution_context.get_output"><code>[method]graph-execution-context.get-output: func</code></a></h4>
 <p>Extract the outputs after inference.</p>
@@ -152,7 +187,7 @@ https://github.com/WebAssembly/wasi-nn/issues/43.</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_graph_execution_context.get_output.0"></a> result&lt;own&lt;<a href="#tensor"><a href="#tensor"><code>tensor</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_graph_execution_context.get_output.0"></a> result&lt;own&lt;<a href="#tensor"><a href="#tensor"><code>tensor</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h2><a name="wasi:nn_graph">Import interface wasi:nn/graph</a></h2>
 <p>A <a href="#graph"><code>graph</code></a> is a loaded instance of a specific ML model (e.g., MobileNet) for a specific ML
@@ -203,7 +238,7 @@ graph IR in parts (e.g., OpenVINO stores its IR and weights separately).</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="method_graph.init_execution_context.0"></a> result&lt;own&lt;<a href="#graph_execution_context"><a href="#graph_execution_context"><code>graph-execution-context</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="method_graph.init_execution_context.0"></a> result&lt;own&lt;<a href="#graph_execution_context"><a href="#graph_execution_context"><code>graph-execution-context</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="load"><code>load: func</code></a></h4>
 <p>Load a <a href="#graph"><code>graph</code></a> from an opaque sequence of bytes to use for inference.</p>
@@ -215,7 +250,7 @@ graph IR in parts (e.g., OpenVINO stores its IR and weights separately).</p>
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="load.0"></a> result&lt;own&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="load.0"></a> result&lt;own&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>
 <h4><a name="load_by_name"><code>load-by-name: func</code></a></h4>
 <p>Load a <a href="#graph"><code>graph</code></a> by name.</p>
@@ -228,5 +263,5 @@ range from simple to complex (e.g., URLs?) and caching mechanisms of various kin
 </ul>
 <h5>Return values</h5>
 <ul>
-<li><a name="load_by_name.0"></a> result&lt;own&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>&gt;, <a href="#error"><a href="#error"><code>error</code></a></a>&gt;</li>
+<li><a name="load_by_name.0"></a> result&lt;own&lt;<a href="#graph"><a href="#graph"><code>graph</code></a></a>&gt;, own&lt;<a href="#error"><a href="#error"><code>error</code></a></a>&gt;&gt;</li>
 </ul>

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -156,10 +156,10 @@ interface errors {
     }
 
     resource error {
-        constructor(error: error-code, data: string);
+        constructor(code: error-code, data: string);
 
         /// Return the error code.
-        error: func() -> error-code;
+        code: func() -> error-code;
 
         /// Errors can propagated with backend specific status through a string value.
         data: func() -> string;

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -133,12 +133,13 @@ interface inference {
 
 /// TODO: create function-specific errors (https://github.com/WebAssembly/wasi-nn/issues/42)
 interface errors {
-    enum error {
+    enum error-code {
         // Caller module passed an invalid argument.
         invalid-argument,
         // Invalid encoding.
         invalid-encoding,
-        busy,
+        // The operation timed out.
+        timeout,
         // Runtime Error.
         runtime-error,
         // Unsupported operation.
@@ -146,6 +147,21 @@ interface errors {
         // Graph is too large.
         too-large,
         // Graph not found.
-        not-found
+        not-found,
+        // The operation is insecure or has insufficient privilege to be performed.
+        // e.g., cannot access a hardware feature requested
+        security,
+        // The operation failed for an unspecified reason.
+        unknown
+    }
+
+    resource error {
+        constructor(error: error-code, data: string);
+
+        /// Return the error code.
+        error: func() -> error-code;
+
+        /// Errors can propagated with backend specific status through a string value.
+        data: func() -> string;
     }
 }


### PR DESCRIPTION
Per discussion in the WebAssembly Machine Learning Group, this proposal is a simple extension to the form of errors propagated by ML backends behind the WASI-NN interface.

The core of the proposal adds an error resource return type which is currently comprised of an explicit error code and a backend specific status message string.  This allows for consistent marshalling of the base return type and framework specific handling of the extended return.

An alternate proposal could be to use the variant type from the Component Model and provide a more hierarchical or structured return.  As the variation is expected to be in vendor specific framework code, the additional expressiveness seems unnecessary.

I also changed "timeout" to "busy" as well as added the "security" and "unknown" error types.