### PR TITLE
add: ggml graph encoding format

### DIFF
--- a/ml.md
+++ b/ml.md
@@ -214,6 +214,7 @@ backends that encode (i.e., serialize) their graph IR with different formats.</p
 <li><a name="graph_encoding.tensorflow"><code>tensorflow</code></a></li>
 <li><a name="graph_encoding.pytorch"><code>pytorch</code></a></li>
 <li><a name="graph_encoding.tensorflowlite"><code>tensorflowlite</code></a></li>
+<li><a name="graph_encoding.ggml"><code>ggml</code></a></li>
 <li><a name="graph_encoding.autodetect"><code>autodetect</code></a></li>
 </ul>
 <h4><a name="execution_target"><code>enum execution-target</code></a></h4>

--- a/wit/wasi-nn.wit
+++ b/wit/wasi-nn.wit
@@ -78,6 +78,7 @@ interface graph {
         tensorflow,
         pytorch,
         tensorflowlite,
+        ggml,
         autodetect,
     }
 


### PR DESCRIPTION
This commit adds the `ggml` graph encoding format to the `graph_encoding` enum.

The motivation for this is to allow the `wasi-nn` interface to support models that are encoded in the `ggml` format which is the model format used by llama.cpp.
